### PR TITLE
make transwhat.py executable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,9 @@ setup(name='transwhat',
 		'transWhat',
 		'Spectrum2'
 	],
+        scripts=[
+		'transWhat/transwhat.py'	
+	],
 	install_requires=[
 		'protobuf',
 		'yowsup2',


### PR DESCRIPTION
by installing transwhat.py as a [script](https://docs.python.org/3/distutils/setupscript.html#installing-scripts), it get's installed in a PATH directory (/usr/bin) and can be executed from there.